### PR TITLE
Improve EZSP client implementation

### DIFF
--- a/src/protocol/ezsp/ashv2.d
+++ b/src/protocol/ezsp/ashv2.d
@@ -1,10 +1,17 @@
 module protocol.ezsp.ashv2;
 
+import urt.array;
+import urt.crc;
 import urt.endian;
 import urt.log;
+import urt.mem.allocator;
 import urt.time;
 
 import router.stream;
+
+//version = DebugASHMessageFlow;
+
+alias ezspCRC = calculate_crc!(Algorithm.crc16_ezsp);
 
 nothrow @nogc:
 
@@ -19,74 +26,74 @@ struct ASH
 {
 nothrow @nogc:
 
-    enum T_RSTACK_MAX           = 3200;
-
-    enum ASH_CANCEL_BYTE        = 0x1A;
-    enum ASH_FLAG_BYTE          = 0x7E;
-    enum ASH_SUBSTITUTE_BYTE    = 0x18;
-    enum ASH_XON_BYTE           = 0x11;
-    enum ASH_OFF_BYTE           = 0x13;
-    enum ASH_TIMEOUT            = -1;
-    enum ASH_MAX_LENGTH         = 131;
-
-    struct SendReq
+    enum Event
     {
-        enum State { Available, ReadyToSend, PendingAck }
-        ushort offset;
-        ubyte length;
-        State state;
+        Reset
     }
 
-    Stream stream;
-
-    ubyte[128] rxBuffer;
-    ubyte[1024] transmitBuffer;
-    SendReq[8] sendQueue;
-    MonoTime lastEvent;
-
-    ushort transmitOffset;
-    ushort recvOffset;
-    ubyte rxOffset;
-
-    ubyte txSeq;
-    ubyte rxSeq;
-    ubyte txAck;
-
-    bool connecting = true;
-    bool connected;
-
-    ubyte ashVersion;
-
-    void delegate(const(ubyte)[] packet) nothrow @nogc packetCallback;
-
-
-    this (Stream stream)
+    this (Stream stream) pure
     {
         this.stream = stream;
+    }
+
+    ~this()
+    {
+        reset();
+
+        while (freeList)
+        {
+            auto next = freeList.next;
+            defaultAllocator.freeT!Message(freeList);
+            freeList = next;
+        }
     }
 
     bool isConnected() const pure
         => connected;
 
-    void setPacketCallback(void delegate(const(ubyte)[]) nothrow @nogc callback)
+    void setEventCallback(void delegate(Event event) nothrow @nogc callback) pure
+    {
+        eventCallback = callback;
+    }
+
+    void setPacketCallback(void delegate(const(ubyte)[]) nothrow @nogc callback) pure
     {
         packetCallback = callback;
     }
 
     void reset(bool reconnect = true)
     {
-        writeDebug("ASHv2: connection reset");
-
         connecting = reconnect;
+
+        if (!connected)
+            return;
         connected = false;
+
+        writeDebug("ASHv2: connection reset");
 
         // clear all the queues...
         txSeq = rxSeq = 0;
+        txAck = 0;
         rxOffset = 0;
-        transmitOffset = recvOffset = 0;
-        sendQueue[] = SendReq();
+
+        // shift all the in-flight packets to the free-list
+        Message* next;
+        while (txInFlight)
+        {
+            next = txInFlight.next;
+            freeMessage(txInFlight);
+            txInFlight = next;
+        }
+        while (txQueue)
+        {
+            next = txQueue.next;
+            freeMessage(txQueue);
+            txQueue = next;
+        }
 
         lastEvent = MonoTime();
+
+        eventCallback(Event.Reset);
     }
 
     void update()
@@ -98,7 +105,7 @@ nothrow @nogc:
 
         if (connecting && !connected && now - lastEvent > T_RSTACK_MAX.msecs && stream.running)
         {
-            writeDebug("ASHv2: connecting...");
+            writeDebug("ASHv2: connecting on '", stream.name, "'...");
             ashRst();
             lastEvent = now;
         }
@@ -109,42 +116,54 @@ nothrow @nogc:
             if (r <= 0)
                 break;
 
-            // skip any XON/OFF bytes
+            // should we record raw bytes, or protocol bytes?
+            rxBytes += r;
+
+            // skip any XON/XOFF bytes
             ubyte rxLen = rxOffset;
             for (ubyte i = rxOffset; i < rxOffset + r; ++i)
             {
-                if (rxBuffer[i] == ASH_XON_BYTE || rxBuffer[i] == ASH_OFF_BYTE)
+                if (rxBuffer[i] == ASH_XON_BYTE || rxBuffer[i] == ASH_XOFF_BYTE)
                     continue;
                 rxBuffer[rxLen++] = rxBuffer[i];
             }
 
-            // parse frames from stream
+            // parse frames from stream delimited by 0x7E bytes
             ubyte start = 0;
             ubyte end = 0;
             bool inputError = false;
             outer: for (; end < rxLen; ++end)
             {
                 if (rxBuffer[end] == ASH_SUBSTITUTE_BYTE)
+                {
+                    // the 'substitution byte' is inserted by the UART in the event of a stream error
+                    // if we receive this byte, we should discard this frame
                     inputError = true;
+                }
                 else if (rxBuffer[end] == ASH_CANCEL_BYTE)
+                {
+                    // the 'cancel byte' is used to cancel the current frame and start over from the next byte
+                    // used to discard any preceeding bytes, for example; rogue bytes emit during system startup, or dangling bytes sent prior to system reset
                     start = cast(ubyte)(end + 1);
+                }
                 if (rxBuffer[end] != ASH_FLAG_BYTE)
                     continue;
 
-                // if we encountered an input error in the stream
+                // if we encountered an input error in the stream (result of a substitution byte), we'll discard this frame
                 if (inputError)
                 {
                     inputError = false;
                     start = cast(ubyte)(end + 1);
+                    ++rxErrors;
                     continue;
                 }
 
-                // remove byte-stuffing
+                // remove byte-stuffing from the frame
                 ubyte frameLen = 0;
                 for (ubyte i = start; i < end; ++i)
                 {
                     ubyte b = rxBuffer[i];
-                    if (b == 0x7D)
+                    if (b == ASH_ESCAPE_BYTE)
                     {
                         if (++i == end)
                         {
@@ -157,197 +176,349 @@ nothrow @nogc:
                         rxBuffer[start + frameLen++] = b;
                 }
 
-                int dataEnd = start + frameLen - 2;
-                ubyte[] frame = rxBuffer[start .. dataEnd];
-
+                ubyte frameStart = start;
                 start = cast(ubyte)(end + 1);
 
-                // validate the frame
-                if (frameLen < 3)
+                if (frameLen < 2)
+                {
+                    if (frameLen != 0)
+                        ++rxErrors;
                     continue;
+                }
+
+                // validate the frame
+                int frameEnd = frameStart + frameLen - 2;
+                ubyte[] frame = rxBuffer[frameStart .. frameEnd];
 
                 // check the crc
-                ushort crc = crcCCITT(frame);
-                if (rxBuffer[dataEnd .. dataEnd + 2][0..2].bigEndianToNative!ushort != crc)
+                const ushort crc = frame.ezspCRC();
+                if (rxBuffer[frameEnd .. frameEnd + 2][0..2].bigEndianToNative!ushort != crc)
                 {
                     // corrupt frame!
                     // TODO: but maybe we should send a NAK?
+                    ++rxErrors;
                     continue;
                 }
 
-                ubyte control = frame[0];
-                frame = frame[1..$];
+                ++rxPackets;
 
-                // handle the frame...
-                if (control == 0xC1)
-                {
-                    // RSTACK
-                    if (frame.length == 2)
-                    {
-                        ashVersion = frame[0];
-                        ubyte code = frame[1];
-
-                        connecting = false; // unsupported version, stop trying to connect!
-                        if (ashVersion == 2)
-                            connected = true;
-
-                        writeDebug(connected ? "ASHv2: connected! code: " : "ASHv2: connection failed; unsupported version! code: ", code);
-                        continue;
-                    }
-                }
-
-                // we can't accept any frames before we receive RSTACK
-                if (!connected)
-                    continue;
-
-                if (control == 0xC2)
-                {
-                    // ERROR
-                    if (frame.length == 2)
-                    {
-                        ubyte ver = frame[0];
-                        ubyte code = frame[1];
-
-                        writeDebug("ASHv2: connection error! code: ", code);
-
-                        // TODO: ...what to do?
-                        reset();
-                    }
-                }
-                else if (control & 0x80)
-                {
-                    if ((control & 0x60) == 0)
-                    {
-                        // ACK
-                        ubyte ackNum = control & 7;
-                        while (txAck != ackNum)
-                        {
-                            // remote acknowledges some frames we've sent
-                            if (sendQueue[txAck].state == SendReq.State.PendingAck)
-                                sendQueue[txAck].state = SendReq.State.Available;
-                            txAck = (txAck + 1) & 7;
-                        }
-
-                        writeDebug("ASHv2: ACK ", ackNum);
-                    }
-                    else if ((control & 0x60) == 0x20)
-                    {
-                        // NAK
-                        writeDebug("ASHv2: NAK ", control & 7);
-
-                        // TODO: I'm meant to retransmit a buffered message
-                        //       ...but it's not clear from the control byte which message(/s) I should retransmit
-                    }
-                    else
-                    {
-                        // Invalid frame!
-                        // ...just ignore it?
-                        debug assert(false);
-                    }
-                }
-                else
-                {
-                    // DATA
-                    ubyte ackNum = control & 7;
-                    while (txAck != ackNum)
-                    {
-                        // remote acknowledges some frames we've sent
-                        if (sendQueue[txAck].state == SendReq.State.PendingAck)
-                            sendQueue[txAck].state = SendReq.State.Available;
-                        txAck = (txAck + 1) & 7;
-                    }
-
-                    ubyte frmNum = control >> 4;
-                    bool retransmit = (control & 0x08) != 0;
-
-                    if (retransmit)
-                    {
-                        // we dispatch ACK's immediately, so if we receive a retransmit, either we missed the first message, or the ack wasn't received
-                        // TODO: if we missed it the first time, we must dispatch it now... how do we know?!
-                        int x = 0;
-                    }
-                    else
-                    {
-                        while (rxSeq != frmNum)
-                        {
-                            // we missed a frame, we should request a retransmit
-                            ashNak(rxSeq, true);
-                            rxSeq = (rxSeq + 1) & 7;
-                        }
-                        rxSeq = (rxSeq + 1) & 7;
-                    }
-
-                    ubyte[ASH_MAX_LENGTH] unrandom = void;
-                    randomise(frame, unrandom[0 .. frame.length]);
-
-                    writeDebug("ASHv2: received data frame ", frmNum, ": ", cast(void[])unrandom[0 .. frame.length]);
-
-                    ubyte curTxSeq = txSeq;
-                    packetCallback(unrandom[0 .. frame.length]);
-
-                    // if the message receive handler didn't send a response, then we should acknowledge the message
-                    if (txSeq == curTxSeq)
-                        ashAck(rxSeq, false);
-                }
+                // submit the frame for processing
+                processFrame(frame);
             }
 
-            if (start > 0)
-                for (size_t i = start; i < rxLen; ++i)
-                    rxBuffer[i - start] = rxBuffer[i];
+            // shuffle any tail bytes (incomplete frames) to the start of the buffer...
             rxOffset = cast(ubyte)(rxLen - start);
+            if (start > 0)
+            {
+                import urt.mem : memmove;
+                memmove(rxBuffer.ptr, rxBuffer.ptr + start, rxOffset);
+            }
         }
         while(true);
 
-        // TODO: handle timeouts...
-        // re-send any failed frames...
-        //...
+        // do we just try and resend the first in the queue?
+        if (txInFlight && now - txInFlight.sendTime >= 250.msecs)
+        {
+            ashNak(txInFlight.seq, false);
+            txInFlight.sendTime = now;
+        }
+    }
+
+    void processFrame(ubyte[] frame)
+    {
+        ubyte control = frame.popFront;
+
+        // check for RSTACK
+        if (control == 0xC1)
+        {
+            if (frame.length == 2)
+            {
+                ashVersion = frame[0];
+                ubyte code = frame[1];
+
+                connecting = false; // unsupported version, stop trying to connect!
+                if (ashVersion == 2)
+                    connected = true;
+
+                writeDebug(connected ? "ASHv2: connected! code=" : "ASHv2: connection failed; unsupported version! code=", code);
+                return;
+            }
+        }
+        // we can't accept any frames before we receive RSTACK
+        if (!connected)
+            return;
+
+        // check for ERROR
+        if (control == 0xC2)
+        {
+            // ERROR
+            if (frame.length == 2)
+            {
+                ubyte ver = frame[0];
+                ubyte code = frame[1];
+
+                writeDebug("ASHv2: <-- ERROR. code=", code);
+            }
+
+            // TODO: ...what to do when receiving an error frame?
+            reset();
+            return;
+        }
+
+        ubyte ackNum = control & 7;
+        int ackAhead = ackNum >= txAck ? ackNum - txAck : ackNum - txAck + 8;
+        if (ackAhead > txAhead())
+            return; // discard frames with invalid ackNum
+
+        // check for other control codes
+        if (control & 0x80)
+        {
+            if ((control & 0x60) == 0)
+            {
+                // ACK
+                version (DebugASHMessageFlow)
+                    writeDebugf("ASHv2: <-- ACK [{0,02x}]", control);
+
+                ackInFlight(ackNum);
+            }
+            else if ((control & 0x60) == 0x20)
+            {
+                // NAK
+                version (DebugASHMessageFlow)
+                    writeDebugf("ASHv2: <-- NAK [{0,02x}]", control);
+
+                // TODO: we're meant to retransmit a buffered message
+                //       ...but it's not clear from the control byte which message(/s) I should retransmit?
+                //       I guess we retransmit all messages from ackNum -> txSeq?
+                //       I guess it should also be the case that ackNum must be the FIRST message in send queue?
+            }
+            else
+            {
+                // Invalid frame!
+                // ...just ignore it?
+                debug assert(false, "TODO: should we do anything here, or just return?");
+            }
+
+            return;
+        }
+
+        // DATA frame
+        ubyte frmNum = control >> 4;
+        bool retransmit = (control & 0x08) != 0;
+
+        // acknowledge frame
+        if (frmNum != rxSeq)
+        {
+            // not the frame we expected; request a retransmit and discard this frame
+            ashNak(rxSeq, false);
+            return;
+        }
+
+        // get data buffer
+        ubyte[] data = void;
+        ubyte[ASH_MAX_LENGTH] tmp = void;
+        data = tmp[0 .. frame.length];
+
+        // de-randomise the frame data
+        randomise(frame, data);
+
+        version (DebugASHMessageFlow)
+            writeDebugf("ASHv2: <-- [x{0, 02x}]: {1}", control, cast(void[])data);
+
+        rxSeq = (rxSeq + 1) & 7;
+        ashAck(rxSeq, false);
+
+        packetCallback(data);
+
+        ackInFlight(ackNum);
+    }
+
+    void ackInFlight(ubyte ackNum)
+    {
+        while (txAck != ackNum)
+        {
+            if (!txInFlight || txInFlight.seq != txAck)
+            {
+                // TODO: what is the proper recovery strategy in this case? reset the connection?
+                assert(false, "We've gone off the rails!");
+            }
+
+            Message* msg = txInFlight;
+            txInFlight = txInFlight.next;
+            freeMessage(msg);
+
+            txAck = (txAck + 1) & 7;
+        }
+
+        // we can send any queued frames here...
+        while (txQueue && txAhead < maxInFlight)
+        {
+            Message* next = txQueue.next;
+            if (!send(txQueue))
+                break;
+            txQueue = next;
+        }
     }
 
     bool send(const(ubyte)[] message)
     {
-        // TODO: what is the maximum length of an EZSP message?
-        assert(message.length <= 128);
+        assert(message.length <= ASH_MAX_MSG_LENGTH);
 
-        SendReq* req = &sendQueue[txSeq];
-        if (req.state != SendReq.State.Available)
+        // TODO: this would be a little nicer if we had a list container...
+
+        Message* msg = allocMessage();
+        msg.length = cast(ubyte)message.length;
+        msg.buffer[0..message.length] = message[];
+        if (txAhead >= maxInFlight || !send(msg))
         {
-            // TODO: we'll discard the existing message...
-            // but the problem is; what if we receive an ack now for the replaced message?
-            // maybe we should try and retransmit?
-            assert(false);
+            // couldn't send immediately; add to send queue
+            if (!txQueue)
+                txQueue = msg;
+            else
+            {
+                Message* m = txQueue;
+                while (m.next)
+                    m = m.next;
+                m.next = msg;
+                msg.next = null;
+            }
         }
+        return true;
+    }
 
-        if (transmitOffset + message.length > transmitBuffer.length)
-            transmitOffset = 0;
+private:
 
-        *req = SendReq(transmitOffset, cast(ubyte)message.length, SendReq.State.ReadyToSend);
+    enum T_RSTACK_MAX           = 3200;
 
-        transmitBuffer[transmitOffset .. transmitOffset + message.length] = message[];
-        transmitOffset += cast(ushort)message.length;
+    enum ASH_CANCEL_BYTE        = 0x1A;
+    enum ASH_FLAG_BYTE          = 0x7E;
+    enum ASH_ESCAPE_BYTE        = 0x7D;
+    enum ASH_SUBSTITUTE_BYTE    = 0x18;
+    enum ASH_XON_BYTE           = 0x11;
+    enum ASH_XOFF_BYTE          = 0x13;
+    enum ASH_TIMEOUT            = -1;
+    enum ASH_MAX_LENGTH         = 131;
+    enum ASH_MAX_MSG_LENGTH     = 128;
 
-        if (!connected || !ashSend(message, txSeq, rxSeq, false))
+    struct Message
+    {
+        Message* next;
+        MonoTime sendTime;
+        ubyte seq;
+        ubyte length;
+        ubyte[ASH_MAX_MSG_LENGTH] buffer;
+
+        ubyte[] payload() pure nothrow @nogc
+            => buffer[0 .. length];
+    }
+
+    void delegate(Event event) nothrow @nogc eventCallback;
+    void delegate(const(ubyte)[] packet) nothrow @nogc packetCallback;
+
+    package Stream stream;
+    MonoTime lastEvent;
+
+    bool connecting = true;
+    bool connected;
+    ubyte ashVersion;
+
+    ubyte maxInFlight = 1; // how many frames we will send without being ack-ed (1-7)
+
+    ubyte txSeq; // the next frame to be sent
+    ubyte txAck = 0; // the next frame we expect an ack for
+    ubyte txAhead() => txSeq >= txAck ? cast(ubyte)(txSeq - txAck) : cast(ubyte)(txSeq - txAck + 8);
+
+    ubyte rxSeq = 0; // the next frame we expect to receive
+
+    uint rxBytes, txBytes;
+    uint rxPackets, txPackets;
+    uint rxErrors, txErrors;
+
+    // TODO: received frames pending delivery because we missed one and sent a NAK
+    Message* txInFlight; // frames that have been sent but not yet ack-ed
+    Message* txQueue;    // frames waiting to be sent
+    Message* freeList;
+
+    ubyte rxOffset;
+    ubyte[128] rxBuffer;
+
+    Message* allocMessage()
+    {
+        Message* msg;
+        if (freeList)
+        {
+            msg = freeList;
+            freeList = freeList.next;
+            msg.seq = 0;
+            msg.next = null;
+        }
+        else
+            msg = defaultAllocator.allocT!Message();
+        msg.sendTime = MonoTime();
+        return msg;
+    }
+    void freeMessage(Message* message)
+    {
+        message.next = freeList;
+        freeList = message;
+    }
+
+    bool send(Message* msg)
+    {
+        if (!connected || !ashSend(msg.payload(), txSeq, rxSeq, false))
             return false;
 
-        writeDebug("ASHv2: sent data frame ", txSeq, ": ", cast(void[])message);
-
-        req.state = SendReq.State.PendingAck;
+        // add to in-flight list
+        msg.next = null;
+        msg.sendTime = getTime();
+        msg.seq = txSeq;
+        if (!txInFlight)
+            txInFlight = msg;
+        else
+        {
+            Message* m = txInFlight;
+            while (m.next)
+                m = m.next;
+            m.next = msg;
+        }
         txSeq = (txSeq + 1) & 7;
 
         return true;
     }
 
-private:
     bool ashRst()
     {
+        version (DebugASHMessageFlow)
+            writeDebug("ASHv2: --> RST");
+
         immutable ubyte[5] RST = [ ASH_CANCEL_BYTE, 0xC0, 0x38, 0xBC, ASH_FLAG_BYTE ];
-        return stream.write(RST) == 5;
+        if (stream.write(RST) != 5)
+        {
+            ++txErrors;
+            return false;
+        }
+        ++txPackets;
+        txBytes += 5;
+        return true;
     }
 
     bool ashAck(ubyte ack, bool ready, bool nak = false)
     {
-        ubyte[4] ackMsg = [ 0x80 | (nak ? 0x20 : 0) | (ready << 3) | (ack & 7), 0, 0, ASH_FLAG_BYTE ];
-        ackMsg[1..3] = crcCCITT(ackMsg[0..1]).nativeToBigEndian;
-        return stream.write(ackMsg) == 4;
+        ubyte control = 0x80 | (nak ? 0x20 : 0) | (ready << 3) | (ack & 7);
+
+        version (DebugASHMessageFlow)
+            writeDebugf("ASHv2: --> {0} [x{1, 02x}]", nak ? "NAK" : "ACK", control);
+
+        ubyte[4] ackMsg = [ control, 0, 0, ASH_FLAG_BYTE ];
+        ackMsg[1..3] = ackMsg[0..1].ezspCRC().nativeToBigEndian;
+        if (stream.write(ackMsg) != 4)
+        {
+            ++txErrors;
+            return false;
+        }
+        ++txPackets;
+        txBytes += 4;
+        return true;
     }
 
     bool ashNak(ubyte ack, bool ready)
@@ -359,23 +530,24 @@ private:
         ubyte[256] frame = void;
 
         // add the control byte
-        frame[0] = ((seq & 7) << 4) | (ack & 7) | (retransmit << 3);
+        ubyte control = ((seq & 7) << 4) | (ack & 7) | (retransmit << 3);
+        frame[0] = control;
 
         // randomise the data
         randomise(msg, frame[1..$]);
 
         // add the crc
-        ushort crc = crcCCITT(frame[0 .. 1 + msg.length]);
+        ushort crc = frame[0 .. 1 + msg.length].ezspCRC();
         frame[1 + msg.length .. 3 + msg.length][0..2] = crc.nativeToBigEndian;
 
         // byte-stuffing
         ubyte[256] stuffed = void;
         size_t len = 0;
-        foreach (i, b; frame[0 .. msg.length + 3])
+        foreach (i, b; frame[0 .. 1 + msg.length + 2])
         {
             if (b == 0x7E || b == 0x7D || b == 0x11 || b == 0x13 || b == 0x18 || b == 0x1A)
             {
-                stuffed[len++] = 0x7D;
+                stuffed[len++] = ASH_ESCAPE_BYTE;
                 stuffed[len++] = b ^ 0x20;
             }
             else
@@ -385,20 +557,31 @@ private:
         // add flag byte
         stuffed[len++] = 0x7E;
 
+        version (DebugASHMessageFlow)
+            writeDebugf("ASHv2: --> [x{0, 02x}]: {1}", control, cast(void[])msg);
+
         ptrdiff_t r = stream.write(stuffed[0..len]);
-        if (r == len)
-            return true;
-        return false;
+        if (r != len)
+        {
+            version (DebugASHMessageFlow)
+                writeDebug("ASHv2: stream write failed!");
+            ++txErrors;
+            return false;
+        }
+
+        ++txPackets;
+        txBytes += r;
+        return true;
     }
 
-    static void randomise(const(ubyte)[] data, ubyte[] buffer)
+    static void randomise(const(ubyte)[] data, ubyte[] buffer) pure
     {
         ubyte rand = 0x42;
         foreach (i, b; data)
         {
             buffer[i] = b ^ rand;
 
-            // which solution is actually better?
+            // TODO: which solution is actually better?
 
             ubyte b1 = cast(ubyte)-(rand & 1) & 0xB8;
             rand = (rand >> 1) ^ b1;
@@ -409,34 +592,4 @@ private:
 //                rand ^= 0xB8;
         }
     }
-}
-
-
-private:
-
-__gshared immutable ushort[256] crcTable = [
-    0x0000, 0x1021, 0x2042, 0x3063, 0x4084, 0x50A5, 0x60C6, 0x70E7, 0x8108, 0x9129, 0xA14A, 0xB16B, 0xC18C, 0xD1AD, 0xE1CE, 0xF1EF,
-    0x1231, 0x0210, 0x3273, 0x2252, 0x52B5, 0x4294, 0x72F7, 0x62D6, 0x9339, 0x8318, 0xB37B, 0xA35A, 0xD3BD, 0xC39C, 0xF3FF, 0xE3DE,
-    0x2462, 0x3443, 0x0420, 0x1401, 0x64E6, 0x74C7, 0x44A4, 0x5485, 0xA56A, 0xB54B, 0x8528, 0x9509, 0xE5EE, 0xF5CF, 0xC5AC, 0xD58D,
-    0x3653, 0x2672, 0x1611, 0x0630, 0x76D7, 0x66F6, 0x5695, 0x46B4, 0xB75B, 0xA77A, 0x9719, 0x8738, 0xF7DF, 0xE7FE, 0xD79D, 0xC7BC,
-    0x48C4, 0x58E5, 0x6886, 0x78A7, 0x0840, 0x1861, 0x2802, 0x3823, 0xC9CC, 0xD9ED, 0xE98E, 0xF9AF, 0x8948, 0x9969, 0xA90A, 0xB92B,
-    0x5AF5, 0x4AD4, 0x7AB7, 0x6A96, 0x1A71, 0x0A50, 0x3A33, 0x2A12, 0xDBFD, 0xCBDC, 0xFBBF, 0xEB9E, 0x9B79, 0x8B58, 0xBB3B, 0xAB1A,
-    0x6CA6, 0x7C87, 0x4CE4, 0x5CC5, 0x2C22, 0x3C03, 0x0C60, 0x1C41, 0xEDAE, 0xFD8F, 0xCDEC, 0xDDCD, 0xAD2A, 0xBD0B, 0x8D68, 0x9D49,
-    0x7E97, 0x6EB6, 0x5ED5, 0x4EF4, 0x3E13, 0x2E32, 0x1E51, 0x0E70, 0xFF9F, 0xEFBE, 0xDFDD, 0xCFFC, 0xBF1B, 0xAF3A, 0x9F59, 0x8F78,
-    0x9188, 0x81A9, 0xB1CA, 0xA1EB, 0xD10C, 0xC12D, 0xF14E, 0xE16F, 0x1080, 0x00A1, 0x30C2, 0x20E3, 0x5004, 0x4025, 0x7046, 0x6067,
-    0x83B9, 0x9398, 0xA3FB, 0xB3DA, 0xC33D, 0xD31C, 0xE37F, 0xF35E, 0x02B1, 0x1290, 0x22F3, 0x32D2, 0x4235, 0x5214, 0x6277, 0x7256,
-    0xB5EA, 0xA5CB, 0x95A8, 0x8589, 0xF56E, 0xE54F, 0xD52C, 0xC50D, 0x34E2, 0x24C3, 0x14A0, 0x0481, 0x7466, 0x6447, 0x5424, 0x4405,
-    0xA7DB, 0xB7FA, 0x8799, 0x97B8, 0xE75F, 0xF77E, 0xC71D, 0xD73C, 0x26D3, 0x36F2, 0x0691, 0x16B0, 0x6657, 0x7676, 0x4615, 0x5634,
-    0xD94C, 0xC96D, 0xF90E, 0xE92F, 0x99C8, 0x89E9, 0xB98A, 0xA9AB, 0x5844, 0x4865, 0x7806, 0x6827, 0x18C0, 0x08E1, 0x3882, 0x28A3,
-    0xCB7D, 0xDB5C, 0xEB3F, 0xFB1E, 0x8BF9, 0x9BD8, 0xABBB, 0xBB9A, 0x4A75, 0x5A54, 0x6A37, 0x7A16, 0x0AF1, 0x1AD0, 0x2AB3, 0x3A92,
-    0xFD2E, 0xED0F, 0xDD6C, 0xCD4D, 0xBDAA, 0xAD8B, 0x9DE8, 0x8DC9, 0x7C26, 0x6C07, 0x5C64, 0x4C45, 0x3CA2, 0x2C83, 0x1CE0, 0x0CC1,
-    0xEF1F, 0xFF3E, 0xCF5D, 0xDF7C, 0xAF9B, 0xBFBA, 0x8FD9, 0x9FF8, 0x6E17, 0x7E36, 0x4E55, 0x5E74, 0x2E93, 0x3EB2, 0x0ED1, 0x1EF0
-];
-
-static ushort crcCCITT(const(ubyte)[] data)
-{
-    ushort crc = 0xFFFF;
-    foreach (b; data)
-        crc = cast(ushort)((crc << 8) ^ crcTable[(crc >> 8) ^ b]);
-    return crc;
 }

--- a/src/protocol/ezsp/client.d
+++ b/src/protocol/ezsp/client.d
@@ -1,6 +1,7 @@
 module protocol.ezsp.client;
 
 import urt.endian;
+import urt.fibre;
 import urt.lifetime;
 import urt.log;
 import urt.map;
@@ -18,6 +19,8 @@ import protocol.ezsp.ashv2;
 
 public import protocol.ezsp.commands;
 
+//version = DebugMessageFlow;
+
 nothrow @nogc:
 
 
@@ -27,55 +30,136 @@ nothrow @nogc:
 //
 
 
+enum IsEZSPRequest(T) = is(typeof(T.Command) : ushort) && is(T.Request == struct) && is(T.Response == struct);
+
+template EZSPArgs(T)
+{
+    static assert(IsEZSPRequest!T, T.stringof ~ " is not an EZSP command structure");
+    alias EZSPArgs = typeof(T.Request.tupleof);
+}
+
+template EZSPResult(T)
+{
+    static assert(IsEZSPRequest!T, T.stringof ~ " is not an EZSP command structure");
+    static if (T.Response.tupleof.length == 0)
+        alias EZSPResult = void;
+    else static if (T.Response.tupleof.length == 1)
+        alias EZSPResult = typeof(T.Response.tupleof[0]);
+    else
+        alias EZSPResult = T.Response;
+}
+
 class EZSPClient : BaseObject
 {
     __gshared Property[1] Properties = [ Property.create!("stream", stream)() ];
-nothrow @nogc:
+@nogc:
 
     enum TypeName = StringLit!"ezsp";
 
-    this(String name, ObjectFlags flags = ObjectFlags.None)
+    enum StackType : ubyte
+    {
+        Unknown = 0,
+        Router = 1,
+        Coordinator = 2
+    }
+
+    this(String name, ObjectFlags flags = ObjectFlags.None) nothrow
     {
         super(collectionTypeInfo!EZSPClient, name.move, flags);
     }
 
     // Properties...
 
-    final inout(Stream) stream() inout pure
+    final inout(Stream) stream() inout pure nothrow
         => ash.stream;
-    final void stream(Stream stream)
+    final void stream(Stream stream) nothrow
     {
         if (ash.stream !is stream)
         {
             // rebuild ASH and reset
             ash = ASH(stream);
+            ash.setEventCallback(&eventCallback);
             ash.setPacketCallback(&incomingPacket);
             restart();
         }
     }
 
-
     // API...
 
-    final void setMessageHandler(void delegate(ubyte sequence, ushort command, const(ubyte)[] message) nothrow @nogc callback)
+    final void reboot() nothrow
+    {
+        sendCommand!EZSP_ResetNode(null);
+        restart();
+    }
+
+    EZSPResult!R request(R)(auto ref EZSPArgs!R args)
+        if (IsEZSPRequest!R)
+    {
+        import urt.util : InPlace, Default;
+
+        assert(isInFibre(), "EZSPClient.request() must be called from a fibre context");
+
+        struct Result
+        {
+            YieldEZSP e;
+            static if (!is(EZSPResult!R == void))
+                EZSPResult!R result;
+        }
+
+        Result r;
+        auto ev = InPlace!YieldEZSP(Default);
+        r.e = ev;
+
+        static void response(void* userData, typeof(R.Response.tupleof) results)
+        {
+            Result* r = cast(Result*)userData;
+            r.e.finished = true;
+            enum numResults = R.Response.tupleof.length;
+            static if (numResults > 1)
+            {
+                static foreach (i; 0 .. numResults)
+                    r.result.tupleof[i] = results[i];
+            }
+            else static if (numResults == 1)
+                r.result = results[0];
+        }
+
+        bool success = sendCommand!R(&response, forward!args, cast(void*)&r);
+        assert(success, "EZSP: failed to send command!");
+
+        yield(ev);
+
+        static if (!is(EZSPResult!R == void))
+            return r.result;
+    }
+
+nothrow:
+    final void setMessageHandler(void delegate(ubyte, ushort, const(ubyte)[]) nothrow @nogc callback) pure nothrow
     {
         messageHandler = callback;
     }
 
     template setCallbackHandler(EZSP_Command)
+        if (IsEZSPRequest!EZSP_Command)
     {
-        static assert(is(typeof(EZSP_Command.Command) : ushort) && is(EZSP_Command.Response == struct),
-                      EZSP_Command.stringof ~ " is not an EZSP command structure");
-
         alias ResponseParams = typeof(EZSP_Command.Response.tupleof);
 
-        final void setCallbackHandler(Callback)(Callback responseHandler, void* userData = null)
+        final void setCallbackHandler(Callback)(Callback responseHandler, void* userData = null) nothrow
         {
             alias Args = Parameters!Callback;
             static assert (is(Args == ResponseParams) || is(Args == AliasSeq!(void*, ResponseParams)), "Callback must be a function with arguments matching " ~ EZSP_Command.stringof ~ ".Response, and optionally a `void* userData` argument in the first position.");
             enum HasUserData = Args.length > 0 && is(Args[0] == void*);
 
-            auto handler = &commandHandlers.insert(EZSP_Command.Command, CommandHandler());
+            version(DebugMessageFlow)
+            {
+                import urt.string.format;
+                if ((EZSP_Command.Command in commandNames) is null)
+                    commandNames.insert(EZSP_Command.Command, CommandData(EZSP_Command.stringof[5 .. $],
+                                                                          (const(ubyte)[] data){ EZSP_Command.Request r; data.ezspDeserialise(r); return tconcat(r); },
+                                                                          (const(ubyte)[] data){ EZSP_Command.Response r; data.ezspDeserialise(r); return tconcat(r); }));
+            }
+
+            auto handler = &commandHandlers.replace(EZSP_Command.Command, CommandHandler());
 
             handler.responseShim = &responseShim!(HasUserData, ResponseParams);
             handler.userData = HasUserData ? userData : null;
@@ -93,34 +177,40 @@ nothrow @nogc:
     }
 
     template sendCommand(EZSP_Command)
+        if (IsEZSPRequest!EZSP_Command)
     {
-        static assert(is(typeof(EZSP_Command.Command) : ushort) && is(EZSP_Command.Request == struct) && is(EZSP_Command.Response == struct),
-                      EZSP_Command.stringof ~ " is not an EZSP command structure");
-
         alias RequestParams = typeof(EZSP_Command.Request.tupleof);
         alias ResponseParams = typeof(EZSP_Command.Response.tupleof);
 
-        final bool sendCommand(Callback)(Callback responseHandler, RequestParams args, void* userData = null)
+        final bool sendCommand(Callback)(Callback responseHandler, auto ref RequestParams args, void* userData = null)
         {
             if (!running)
                 return false;
 
-            alias Args = Parameters!Callback;
-            static assert (is(Args == ResponseParams) || is(Args == AliasSeq!(void*, ResponseParams)), "Callback must be a function with arguments matching " ~ EZSP_Command.stringof ~ ".Response, and optionally a `void* userData` argument in the first position.");
-            enum HasUserData = Args.length > 0 && is(Args[0] == void*);
+            static if (!is(Callback == typeof(null)))
+            {
+                alias Args = Parameters!Callback;
+                static assert (is(Args == ResponseParams) || is(Args == AliasSeq!(void*, ResponseParams)), "Callback must be a function with arguments matching " ~ EZSP_Command.stringof ~ ".Response, and optionally a `void* userData` argument in the first position.");
+                enum HasUserData = Args.length > 0 && is(Args[0] == void*);
+            }
+
+            version(DebugMessageFlow)
+            {
+                import urt.string.format;
+                if ((EZSP_Command.Command in commandNames) is null)
+                    commandNames.insert(EZSP_Command.Command, CommandData(EZSP_Command.stringof[5 .. $],
+                                                                          (const(ubyte)[] data){ EZSP_Command.Request r; data.ezspDeserialise(r); return tconcat(r); },
+                                                                          (const(ubyte)[] data){ EZSP_Command.Response r; data.ezspDeserialise(r); return tconcat(r); }));
+            }
 
             ubyte[EZSP_Command.Request.sizeof] buffer = void;
-            size_t offset = 0;
-            static foreach (i; 0 .. RequestParams.length)
-            {{
-                size_t len = args[i].ezspSerialise(buffer[offset..$]);
-                assert(len != 0, "Request buffer too small! How did we miscalculate this?");
-                offset += len;
-            }}
+            EZSP_Command.Request tr = void;
+            tr.tupleof[] = args[];
+            size_t offset = tr.ezspSerialise(buffer[]);
 
-            writeInfof("EZSP: sending request - " ~ EZSP_Command.stringof ~ "(x{0, 04x})", EZSP_Command.Command);
-
-            static if (is_delegate!Callback)
+            static if (is(Callback == typeof(null)))
+                return sendCommandImpl(EZSP_Command.Command, buffer[0..offset], null, null, null, null);
+            else static if (is_delegate!Callback)
                 return sendCommandImpl(EZSP_Command.Command, buffer[0..offset], &responseShim!(HasUserData, ResponseParams), responseHandler.funcptr, responseHandler.ptr, HasUserData ? userData : null);
             else
                 return sendCommandImpl(EZSP_Command.Command, buffer[0..offset], &responseShim!(HasUserData, ResponseParams), responseHandler, null, HasUserData ? userData : null);
@@ -156,11 +246,21 @@ nothrow @nogc:
         buffer[i .. i + data.length] = data[];
         i += data.length;
 
+        version(DebugMessageFlow)
+        {
+            CommandData* cmdName = cmd in commandNames;
+            writeDebugf("EZSP: --> [{0}] - {1}(x{2, 04x}) - {3,?5}{4,!5}", sequenceNumber, cmdName ? cmdName.name : "UNKNOWN", cmd, cmdName ? cmdName.reqFmt(buffer[5..i]) : null, cast(void[])buffer[0..i], cmdName !is null);
+        }
+
         if (!ash.send(buffer[0..i]))
         {
+            version(DebugMessageFlow)
+                writeDebug("EZSP: send failed!");
+
             // error?!
             return -1;
         }
+
         return sequenceNumber++;
     }
 
@@ -203,7 +303,7 @@ nothrow @nogc:
 
     final override void update()
     {
-        if (!enabled || !validate())
+        if (!validate())
             return;
 
         ash.update();
@@ -231,6 +331,13 @@ nothrow @nogc:
 
 private:
 
+    static class YieldEZSP : AwakenEvent
+    {
+        nothrow @nogc:
+        bool finished;
+        override bool ready() { return finished; }
+    }
+
     struct ActiveRequests
     {
         void function(const(ubyte)[], void*, void*, void*) nothrow @nogc responseShim;
@@ -252,10 +359,10 @@ private:
 
     MonoTime lastEvent;
 
-    bool enabled = true;
-
     ubyte requestedVersion;
     ubyte knownVersion;
+    StackType stackType;
+    String stackVersion;
 
     ubyte sequenceNumber;
 
@@ -265,37 +372,78 @@ private:
     Map!(ushort, CommandHandler) commandHandlers;
     ActiveRequests[16] activeRequests;
 
+    version(DebugMessageFlow)
+    {
+        struct CommandData
+        {
+            string name;
+            const(char)[] function(const(ubyte)[]) nothrow @nogc reqFmt;
+            const(char)[] function(const(ubyte)[]) nothrow @nogc resFmt;
+        }
+        Map!(ushort, CommandData) commandNames;
+    }
+
+    void eventCallback(ASH.Event event)
+    {
+        if (event == ASH.Event.Reset)
+        {
+            knownVersion = 0;
+            requestedVersion = 0;
+            sequenceNumber = 0;
+            stackType = StackType.Unknown;
+            stackVersion = null;
+            activeRequests[] = ActiveRequests();
+        }
+        else
+            assert(false, "Unhandled ASH event");
+    }
+
     void incomingPacket(const(ubyte)[] msg)
     {
-        ubyte seq = msg[0];
+//        writeWarningf("ASHv2: [!!!] empty frame received! [x{0,02x}]", control);
+
+        ubyte seq;
         ushort control;
         ushort cmd;
         if (knownVersion >= 8)
         {
-            assert(msg.length >= 5);
+            if (msg.length < 5)
+            {
+                writeWarning("EZSP: [!!!] invalid frame; frame is too short!");
+                return;
+            }
 
+            seq = msg[0];
             control = msg[1] | (msg[2] << 8);
             cmd = msg[3] | (msg[4] << 8);
             msg = msg[5 .. $];
         }
         else
         {
-            assert(msg.length >= 4);
+            if (msg.length < 3)
+            {
+                writeWarning("EZSP: [!!!] invalid frame; frame is too short!");
+                return;
+            }
 
+            seq = msg[0];
             control = msg[1];
 
-            if (msg.length >= 3 && msg[2] == 0xff)
+            if (msg[2] == 0xff)
             {
                 assert(false); // TODO: we don't understand this case!
-                if (msg.length < 4)
-                    assert(false);
+
+                if (msg.length < 5)
+                {
+                    writeWarning("EZSP: [!!!] invalid frame; frame is too short!");
+                    return;
+                }
+
                 cmd = msg[4];
                 msg = msg[5..$];
             }
             else
             {
-                assert(msg.length >= 3);
-
                 cmd = msg[2];
                 msg = msg[3..$];
             }
@@ -334,18 +482,30 @@ private:
                     break;
                 }
 
+                import urt.string.format : tformat;
+                import urt.mem.allocator : defaultAllocator;
+
+                stackType = cast(StackType)r.stackType;
+                stackVersion = tformat("{0}.{1}.{2}.{3}", r.stackVersion >> 12, (r.stackVersion >> 8) & 0xF, (r.stackVersion >> 4) & 0xF, r.stackVersion & 0xF).makeString(defaultAllocator());
+
                 knownVersion = requestedVersion;
                 requestedVersion = 0;
 
-                writeInfo("EZSP: agreed version: ", knownVersion);
+                writeInfof("EZSP: connected: {0} V{1} - protocol version {2}", r.stackType == 1 ? "ROUTER" : r.stackType == 2 ? "COORDINATOR" : "UNKNOWN", stackVersion, knownVersion);
                 break;
 
             case 0x0058: // invalidCommand
                 EzspStatus reason = cast(EzspStatus)msg[0];
-                writeInfo("EZSP: invalid command: ", reason);
+                writeWarning("EZSP: invalid command: ", reason);
                 break;
 
             default:
+                version(DebugMessageFlow)
+                {
+                    CommandData* cmdName = command in commandNames;
+                    writeDebugf("EZSP: <-- [{0}] - {1}(x{2,04x}) - {3,?5}{4,!5}", seq, cmdName ? cmdName.name : "UNKNOWN", command, cmdName ? cmdName.resFmt(msg) : null, cast(void[])msg, cmdName !is null);
+                }
+
                 int slot = seq & 0xF;
                 if (activeRequests[slot].responseShim != null)
                 {
@@ -359,7 +519,9 @@ private:
                     else if (messageHandler)
                         messageHandler(seq, command, msg);
                     else
-                        writeInfof("EZSP: unhandled message - seq: {0}  cmd: x{1,04x} - {2}", seq, command, cast(void[])msg);
+                    {
+                        // TODO: unhandled message?
+                    }
                 }
                 break;
         }
@@ -393,11 +555,16 @@ void responseShim(bool withUserdata, Args...)(const(ubyte)[] response, void* cb,
     import urt.meta.tuple;
 
     Tuple!Args args;
-    size_t taken = response.ezspDeserialise(args);
-    if (taken != response.length)
+    static if (Args.length > 0)
     {
-        writeWarning("EZSP: error deserialising response");
-        return;
+        size_t taken = response.ezspDeserialise(args);
+        if (taken == 0 || taken > response.length)
+        {
+            writeWarning("EZSP: error deserialising response");
+            return;
+        }
+        if (taken < response.length)
+            writeWarning("EZSP: response buffer contains more bytes than expected! tail bytes: ", cast(void[])response[taken .. $]);
     }
 
     if (inst)
@@ -418,4 +585,3 @@ void responseShim(bool withUserdata, Args...)(const(ubyte)[] response, void* cb,
             (cast(void function(Args) nothrow @nogc)cb)(args.expand);
     }
 }
-

--- a/src/protocol/ezsp/commands.d
+++ b/src/protocol/ezsp/commands.d
@@ -4,7 +4,7 @@ nothrow @nogc:
 
 
 // HACK: what is this? Why the spec randomly uses this for signal powers?
-alias int8s = ubyte;
+alias int8s = byte;
 
 
 // Identifies a configuration value.
@@ -134,16 +134,16 @@ enum EmberConfigTxPowerMode : ushort {
 
 // Identifies a policy.
 enum EzspPolicyId : ubyte {
-    TRUST_CENTER_POLICY = 0x00, // Controls trust center behavior.
-    BINDING_MODIFICATION_POLICY = 0x01, // Controls how external binding modification requests are handled.
-    UNICAST_REPLIES_POLICY = 0x02, // Controls whether the Host supplies unicast replies.
-    POLL_HANDLER_POLICY = 0x03, // Controls whether pollHandler callbacks are generated.
-    MESSAGE_CONTENTS_IN_CALLBACK_POLICY = 0x04, // Controls whether the message contents are included in the messageSentHandler callback.
-    TC_KEY_REQUEST_POLICY = 0x05, // Controls whether the Trust Center will respond to Trust Center link key requests.
-    APP_KEY_REQUEST_POLICY = 0x06, // Controls whether the Trust Center will respond to application link key requests.
-    PACKET_VALIDATE_LIBRARY_POLICY = 0x07, // Controls whether ZigBee packets that appear invalid are automatically dropped by the stack. A counter will be incremented when this occurs.
-    ZLL_POLICY = 0x08, // Controls whether the stack will process ZLL messages.
-    TC_REJOINS_USING_WELL_KNOWN_KEY_POLICY = 0x09, // Controls whether Trust Center (insecure) rejoins for devices using the well-known link key are accepted. If rejoining using the well-known key is allowed, it is disabled again after sli_zigbee_allow_tc_rejoins_using_well_known_key_timeout_sec seconds.
+    TRUST_CENTER = 0x00, // Controls trust center behavior.
+    BINDING_MODIFICATION = 0x01, // Controls how external binding modification requests are handled.
+    UNICAST_REPLIES = 0x02, // Controls whether the Host supplies unicast replies.
+    POLL_HANDLER = 0x03, // Controls whether pollHandler callbacks are generated.
+    MESSAGE_CONTENTS_IN_CALLBACK = 0x04, // Controls whether the message contents are included in the messageSentHandler callback.
+    TC_KEY_REQUEST = 0x05, // Controls whether the Trust Center will respond to Trust Center link key requests.
+    APP_KEY_REQUEST = 0x06, // Controls whether the Trust Center will respond to application link key requests.
+    PACKET_VALIDATE_LIBRARY = 0x07, // Controls whether ZigBee packets that appear invalid are automatically dropped by the stack. A counter will be incremented when this occurs.
+    ZLL = 0x08, // Controls whether the stack will process ZLL messages.
+    TC_REJOINS_USING_WELL_KNOWN_KEY = 0x09, // Controls whether Trust Center (insecure) rejoins for devices using the well-known link key are accepted. If rejoining using the well-known key is allowed, it is disabled again after sli_zigbee_allow_tc_rejoins_using_well_known_key_timeout_sec seconds.
 }
 
 // This is the policy decision bitmask that controls the trust center decision strategies. The bitmask is modified and extracted from the EzspDecisionId for supporting bitmask operations.
@@ -1318,10 +1318,8 @@ struct EZSP_AddEndpoint {
         ushort profileId; // The endpoint's application profile.
         ushort deviceId; // The endpoint's device ID within the application profile.
         ubyte appFlags; // The device version and flags indicating description availability.
-        ubyte inputClusterCount; // The number of cluster IDs in inputClusterList.
-        ubyte outputClusterCount; // The number of cluster IDs in outputClusterList.
-        ushort[] inputClusterList; // Input cluster IDs the endpoint will accept.
-        ushort[] outputClusterList; // Output cluster IDs the endpoint may send.
+        const(ushort)[] inputClusterList; // Input cluster IDs the endpoint will accept.
+        const(ushort)[] outputClusterList; // Output cluster IDs the endpoint may send.
     }
     struct Response {
         EzspStatus status; // EZSP_SUCCESS if the endpoint was added, EZSP_ERROR_OUT_OF_MEMORY if there is not enough memory available to add the endpoint, EZSP_ERROR_INVALID_VALUE if the endpoint already exists, EZSP_ERROR_INVALID_CALL if endpoints can no longer be added.
@@ -1395,8 +1393,7 @@ struct EZSP_SetValue {
     enum ushort Command = 0x00AB;
     struct Request {
         EzspValueId valueId; // Identifies which value to change.
-        ubyte valueLength; // The length of the value parameter in bytes.
-        ubyte[] value; // The new value.
+        const(ubyte)[] value; // The new value.
     }
     struct Response {
         EzspStatus status;
@@ -1671,8 +1668,7 @@ struct EZSP_CustomFrameHandler {
     struct Request {
     }
     struct Response {
-        ubyte payloadLength; // The length of the custom frame payload.
-        ubyte[] payload; // The payload of the custom frame.
+        const(ubyte)[] payload; // The payload of the custom frame.
     }
 }
 
@@ -2520,8 +2516,7 @@ struct EZSP_SendUnicast {
         EmberNodeId indexOrDestination; // Depending on the type of addressing used, this is either the EmberNodeId of the destination, an index into the address table, or an index into the binding table.
         EmberApsFrame apsFrame; // The APS frame which is to be added to the message.
         ubyte messageTag; // A value chosen by the Host. This value is used in the ezspMessageSentHandler response to refer to this message.
-        ubyte messageLength; // The length of the messageContents parameter in bytes.
-        ubyte[] messageContents; // Content of the message.
+        const(ubyte)[] messageContents; // Content of the message.
     }
     struct Response {
         EmberStatus status; // An EmberStatus value indicating success or the reason for failure.
@@ -2537,8 +2532,7 @@ struct EZSP_SendBroadcast {
         EmberApsFrame apsFrame; // The APS frame for the message.
         ubyte radius; // The message will be delivered to all nodes within radius hops of the sender. A radius of zero is converted to EMBER_MAX_HOPS.
         ubyte messageTag; // A value chosen by the Host. This value is used in the ezspMessageSentHandler response to refer to this message.
-        ubyte messageLength; // The length of the messageContents parameter in bytes.
-        ubyte[] messageContents; // The broadcast message.
+        const(ubyte)[] messageContents; // The broadcast message.
     }
     struct Response {
         EmberStatus status; // An EmberStatus value indicating success or the reason for failure.
@@ -2626,8 +2620,7 @@ struct EZSP_MessageSentHandler {
         EmberApsFrame apsFrame; // The APS frame for the message.
         ubyte messageTag; // The value supplied by the Host in the ezspSendUnicast, ezspSendBroadcast or ezspSendMulticast command.
         EmberStatus status; // An EmberStatus value of EMBER_SUCCESS if an ACK was received from the destination or EMBER_DELIVERY_FAILED if no ACK was received.
-        ubyte messageLength; // The length of the messageContents parameter in bytes.
-        ubyte[] messageContents; // The unicast message supplied by the Host. The message contents are only included here if the decision for the messageContentsInCallback policy is messageTagAndContentsInCallback.
+        const(ubyte)[] message; // The unicast message supplied by the Host. The message contents are only included here if the decision for the messageContentsInCallback policy is messageTagAndContentsInCallback.
     }
 }
 
@@ -2704,8 +2697,7 @@ struct EZSP_IncomingMessageHandler {
         EmberNodeId sender; // The sender of the message.
         ubyte bindingIndex; // The index of a binding that matches the message or 0xFF if there is no matching binding.
         ubyte addressIndex; // The index of the entry in the address table that matches the sender of the message or 0xFF if there is no matching entry.
-        ubyte messageLength; // The length of the messageContents parameter in bytes.
-        ubyte[] messageContents; // The incoming message.
+        const(ubyte)[] message; // The incoming message.
     }
 }
 
@@ -2965,8 +2957,7 @@ struct EZSP_MacPassthroughMessageHandler {
         EmberMacPassthroughType messageType; // The type of MAC passthrough message received.
         ubyte lastHopLqi; // The link quality from the node that last relayed the message.
         int8s lastHopRssi; // The energy level (in units of dBm) observed during reception.
-        ubyte messageLength; // The length of the messageContents parameter in bytes.
-        ubyte[] messageContents; // The raw message that was received.
+        const(ubyte)[] message; // The raw message that was received.
     }
 }
 

--- a/src/protocol/ezsp/package.d
+++ b/src/protocol/ezsp/package.d
@@ -45,16 +45,38 @@ size_t ezspSerialise(T)(ref T data, ubyte[] buffer)
 
     static if (is(T == struct))
     {
-        size_t length = 0;
-        static foreach(ref m; s.tupleof)
-        {
-            alias M = typeof(m);
-            size_t len = ezspSerialise(m, buffer[length..$]);
-            if (len == 0)
-                return 0;
-            length += len;
-        }
-        return length;
+        size_t bytes = 0;
+        alias members = data.tupleof;
+        static foreach(i; 0 .. members.length)
+        {{
+            static if (is(typeof(members[i]) == const(ushort)[]))
+            {
+                // HACK: EZSP_AddEndpoint is the only message that has a ushort[], and that message is
+                //       special because there are 2 arrays back-to-back, so it needs this hack to write
+                //       the in-clusters and out-clusters in one sequence with 2 length's prepended
+                static if (i == members.length - 2)
+                {
+                    size_t len = (members[i].length + members[i + 1].length)*2;
+                    if (buffer.length < bytes + 2 + len)
+                        return 0;
+                    buffer[bytes++] = cast(ubyte)members[i].length;
+                    buffer[bytes++] = cast(ubyte)members[i + 1].length;
+                    ushort* arr = cast(ushort*)(buffer.ptr + bytes);
+                    arr[0 .. members[i].length] = members[i];
+                    arr += members[i].length;
+                    arr[0 .. members[i + 1].length] = members[i + 1];
+                    bytes += len;
+                }
+            }
+            else
+            {
+                size_t len = ezspSerialise(members[i], buffer[bytes..$]);
+                if (len == 0)
+                    return 0;
+                bytes += len;
+            }
+        }}
+        return bytes;
     }
     else static if (is(T == ubyte[N], size_t N))
     {
@@ -62,6 +84,19 @@ size_t ezspSerialise(T)(ref T data, ubyte[] buffer)
             return 0;
         buffer[0 .. N] = data;
         return N;
+    }
+    else static if (is(T == ubyte[]))
+    {
+        static assert(false, "TODO: This struct message is not yet supported!");
+    }
+    else static if (is(T : const(ubyte)[]))
+    {
+        assert(data.length <= 255, "Data must be <= 255 bytes");
+        if (buffer.length < 1 + data.length)
+            return 0;
+        buffer[0] = cast(ubyte)data.length;
+        buffer[1 .. 1 + data.length] = data[];
+        return 1 + data.length;
     }
     else
     {
@@ -82,10 +117,33 @@ size_t ezspDeserialise(T)(const(ubyte)[] data, out T t)
         alias tup = t.tupleof;
         static foreach(i; 0..tup.length)
         {{
-            size_t took = data[offset..$].ezspDeserialise(tup[i]);
-            if (took == 0)
-                return 0;
-            offset += took;
+            static if (is(typeof(tup[i]) == const(ushort)[]))
+            {
+                // HACK: EZSP_AddEndpoint is the only message that has a ushort[], and that message is
+                //       special because there are 2 arrays back-to-back, so it needs this hack to write
+                //       the in-clusters and out-clusters in one sequence with 2 length's prepended
+                static if (i == tup.length - 2)
+                {
+                    if (data.length < offset + 2)
+                        return 0;
+                    ubyte len1 = data.ptr[offset];
+                    ubyte len2 = data.ptr[offset + 1];
+                    size_t len = 2 + (len1 + len2)*2;
+                    if (data.length < offset + len)
+                        return 0;
+                    const arr = cast(ushort*)(data.ptr + offset + 2);
+                    tup[i] = arr[0 .. len1];
+                    tup[i + 1] = (arr + len1)[0 .. len2];
+                    offset += len;
+                }
+            }
+            else
+            {
+                size_t took = data.ptr[offset..data.length].ezspDeserialise(tup[i]);
+                if (took == 0)
+                    return 0;
+                offset += took;
+            }
         }}
         return offset;
     }
@@ -93,14 +151,21 @@ size_t ezspDeserialise(T)(const(ubyte)[] data, out T t)
     {
         if (data.length < N)
             return 0;
-        t = data[0 .. N];
+        t = data.ptr[0 .. N];
         return N;
+    }
+    else static if (is(T : const(ubyte)[]))
+    {
+        if (data.length < 1 || data.length < 1 + data[0])
+            return 0;
+        t = (data.ptr + 1)[0 .. data[0]];
+        return 1 + t.length;
     }
     else
     {
         if (data.length < T.sizeof)
             return 0;
-        t = data[0 .. T.sizeof].littleEndianToNative!T;
+        t = data.ptr[0 .. T.sizeof].littleEndianToNative!T;
         return T.sizeof;
     }
 }


### PR DESCRIPTION
I'm so sorry, this is essentially a rewrite!
Probably best to just do a once-over the affected files rather than try to follow the diff's.

There's 2 things going on here; one protocol called ASHv2, which puts a reliability layer over a serial bitstream to frame EZSP protocol packets, which is a command-response protocol with an NCP (network co-processor).
EZSPClient is a client interface for the NCP protocol, used to implement a Zigbee driver (coming soon!).