### PR TITLE
Fix the cli newline parsing.

### DIFF
--- a/src/manager/console/session.d
+++ b/src/manager/console/session.d
@@ -265,7 +265,7 @@ nothrow @nogc:
                     i += 1;
                     goto close_session;
                 }
-                else if (t[i] == '\r')
+                else if (t[i] == '\r' || t[i] == '\n')
                 {
                     return i;
                 }
@@ -417,12 +417,8 @@ protected:
             }
             else if (taken < input.length)
             {
-                assert(input[taken] == '\r', "Should only be here when user presses enter?");
-
-//                // TODO: what about not-telnet?
-//                //       consume following '\n'?? do enter keypresses expect a '\n'? maybe ClientFeatures.CRLF?
-//                if (taken + 1 < input.length && (input[taken + 1] == '\n'))
-//                    ++taken;
+                if (input[taken] == '\r' && input.length > taken + 1 && input[taken + 1] == '\n')
+                    ++taken;
 
                 MutableString!0 cmdInput = takeInput();
                 const(char)[] command = cmdInput.trimCmdLine;

--- a/src/router/stream/tcp.d
+++ b/src/router/stream/tcp.d
@@ -477,6 +477,8 @@ nothrow @nogc:
 //        if (options & ServerOptions.JustOne)
 //            stop();
 
+        conn.set_socket_option(SocketOption.non_blocking, true);
+
         // prevent duplicate stream names...
         String newName = getModule!StreamModule.streams.generateName(name).makeString(defaultAllocator());
 


### PR DESCRIPTION
THIS PATCH GETS ARM64 RUNNING ON MY PI

The original code here only works on Windows and Telnet...
This change worries me, because there's obviously a really good reason the code was the way it was; if only I could remember!

There's a lot of complexity in this terminal parsing code... I feel like it needs a good overhaul; it's evolved and mutated a lot. I reckon it probably wouldn't hurt to translate the newlines at the point the input is initially received... but again, I reckon there's some reasons I didn't do that in the first place.

Also on Windows, `accept`ed sockets inherit non-blocking from the server, but on linux they don't, so the TCP server's connections were all blocking :/