### PR TITLE
Improve ObjectRef; fix a bug, add a self-reattach function.

### DIFF
--- a/src/protocol/http/client.d
+++ b/src/protocol/http/client.d
@@ -86,11 +86,7 @@ nothrow @nogc:
 
     override CompletionStatus validating()
     {
-        if (_stream.detached)
-        {
-            if (Stream s = get_module!StreamModule.streams.get(_stream.name))
-                _stream = s;
-        }
+        _stream.try_reattach();
         return super.validating();
     }
 

--- a/src/router/iface/can.d
+++ b/src/router/iface/can.d
@@ -97,11 +97,7 @@ nothrow @nogc:
 
     override CompletionStatus validating()
     {
-        if (_stream.detached)
-        {
-            if (Stream s = get_module!StreamModule.streams.get(_stream.name))
-                _stream = s;
-        }
+        _stream.try_reattach();
         return super.validating();
     }
 

--- a/src/router/iface/modbus.d
+++ b/src/router/iface/modbus.d
@@ -173,11 +173,7 @@ nothrow @nogc:
 
     override CompletionStatus validating()
     {
-        if (_stream.detached)
-        {
-            if (Stream s = get_module!StreamModule.streams.get(_stream.name))
-                _stream = s;
-        }
+        _stream.try_reattach();
         return super.validating();
     }
 

--- a/src/router/iface/package.d
+++ b/src/router/iface/package.d
@@ -406,6 +406,11 @@ nothrow @nogc:
 
     override void init()
     {
+        // HACK: BaseInterface collection is not a natural collection, so we'll init it here...
+        ref Collection!BaseInterface* c = collection_for!BaseInterface();
+        assert(c is null, "Collection has been registered before!");
+        c = &interfaces;
+
         g_app.console.registerCommand!print("/interface", this);
     }
 

--- a/src/router/iface/tesla.d
+++ b/src/router/iface/tesla.d
@@ -65,6 +65,12 @@ nothrow @nogc:
     override bool validate() const
         => _stream !is null;
 
+    override CompletionStatus validating()
+    {
+        _stream.try_reattach();
+        return super.validating();
+    }
+
     override CompletionStatus startup()
     {
         if (!_stream)

--- a/src/router/stream/bridge.d
+++ b/src/router/stream/bridge.d
@@ -59,8 +59,11 @@ nothrow @nogc:
         // read all streams, echo to other streams, accumulate input buffer
         foreach (i; 0 .. m_streams.length)
         {
-            if (!m_streams[i] || !m_streams[i].running)
-                continue;
+            if (!m_streams[i])
+            {
+                if (!m_streams[i].try_reattach() || !m_streams[i].running)
+                    continue;
+            }
 
             ubyte[1024] buf;
             size_t bytes;

--- a/src/router/stream/package.d
+++ b/src/router/stream/package.d
@@ -208,6 +208,14 @@ class StreamModule : Module
 nothrow @nogc:
 
     Collection!Stream streams;
+
+    override void init()
+    {
+        // HACK: Stream collection is not a natural collection, so we'll init it here...
+        ref Collection!Stream* c = collection_for!Stream();
+        assert(c is null, "Collection has been registered before!");
+        c = &streams;
+    }
 }
 
 


### PR DESCRIPTION
The assignment operator didn't handle `null` cases correctly.
Add `try_reattach` which will attempt to self-reattach using the new `collectionFor!Type` tool, and remove a bunch of bespoke code.